### PR TITLE
Split the path with the name for model

### DIFF
--- a/assets/configs/Config.toml
+++ b/assets/configs/Config.toml
@@ -1,9 +1,10 @@
 [model]
+model_name = "RWKV-x060-World-1B6-v2-20240208-ctx4096.st" # Path to the model.
+model_path = "assets/models"
 embed_device = "Cpu"                                             # Device to put the embed tensor ("Cpu" or "Gpu").
 head_chunk_size = 8192                                           # DO NOT modify this if you don't know what you are doing.
 max_batch = 16                                                   # The maximum batches that are cached on GPU.
 max_runtime_batch = 8                                            # The maximum batches that can be scheduled for inference at the same time.
-path = "assets/models/RWKV-x060-World-3B-v2-20240228-ctx4096.st" # Path to the model.
 quant = 0                                                        # Layers to be quantized.
 quant_type = "Int8"                                              # Quantization type ("Int8" or "NF4").
 state_chunk_size = 4                                             # The chunk size of layers in model state.

--- a/src/api/adapter.rs
+++ b/src/api/adapter.rs
@@ -7,7 +7,7 @@ mod private {
     use crate::middleware::{AdapterList, ThreadRequest, ThreadState};
 
     /// `/api/adapters`.
-    pub async fn adapters(State(ThreadState(sender)): State<ThreadState>) -> Json<Vec<String>> {
+    pub async fn adapters(State(ThreadState(sender, _)): State<ThreadState>) -> Json<Vec<String>> {
         let (list_sender, list_receiver) = flume::unbounded();
         let _ = sender.send(ThreadRequest::Adapter(list_sender));
         let AdapterList(list) = list_receiver.recv_async().await.unwrap_or_default();
@@ -25,7 +25,7 @@ mod private {
     #[handler]
     pub async fn adapters(depot: &mut Depot) -> Json<Vec<String>> {
         let (list_sender, list_receiver) = flume::unbounded();
-        let ThreadState(sender) = depot.obtain::<ThreadState>().unwrap();
+        let ThreadState(sender, _) = depot.obtain::<ThreadState>().unwrap();
         let _ = sender.send(ThreadRequest::Adapter(list_sender));
         let AdapterList(list) = list_receiver.recv_async().await.unwrap_or_default();
         Json(list)

--- a/src/api/oai/chat.rs
+++ b/src/api/oai/chat.rs
@@ -194,7 +194,7 @@ mod private {
     };
 
     async fn respond_one(
-        State(ThreadState(sender)): State<ThreadState>,
+        State(ThreadState(sender, _)): State<ThreadState>,
         Json(request): Json<ChatRequest>,
     ) -> Json<ChatResponse> {
         let info = request_info(sender.clone(), Duration::from_secs(1)).await;
@@ -244,7 +244,7 @@ mod private {
     }
 
     async fn respond_stream(
-        State(ThreadState(sender)): State<ThreadState>,
+        State(ThreadState(sender, _)): State<ThreadState>,
         Json(request): Json<ChatRequest>,
     ) -> Sse<impl Stream<Item = Result<Event>>> {
         let info = request_info(sender.clone(), Duration::from_secs(1)).await;
@@ -320,7 +320,7 @@ mod private {
     };
 
     async fn respond_one(depot: &mut Depot, request: ChatRequest, res: &mut Response) {
-        let ThreadState(sender) = depot.obtain::<ThreadState>().unwrap();
+        let ThreadState(sender, _) = depot.obtain::<ThreadState>().unwrap();
         let info = request_info(sender.clone(), Duration::from_secs(1)).await;
         let model_name = info.reload.model_path.to_string_lossy().into_owned();
 
@@ -369,7 +369,7 @@ mod private {
     }
 
     async fn respond_stream(depot: &mut Depot, request: ChatRequest, res: &mut Response) {
-        let ThreadState(sender) = depot.obtain::<ThreadState>().unwrap();
+        let ThreadState(sender, _) = depot.obtain::<ThreadState>().unwrap();
         let info = request_info(sender.clone(), Duration::from_secs(1)).await;
         let model_name = info.reload.model_path.to_string_lossy().into_owned();
 

--- a/src/api/oai/completion.rs
+++ b/src/api/oai/completion.rs
@@ -127,7 +127,7 @@ mod private {
     };
 
     async fn respond_one(
-        State(ThreadState(sender)): State<ThreadState>,
+        State(ThreadState(sender, _)): State<ThreadState>,
         Json(request): Json<CompletionRequest>,
     ) -> Json<CompletionResponse> {
         let info = request_info(sender.clone(), Duration::from_secs(1)).await;
@@ -174,7 +174,7 @@ mod private {
     }
 
     async fn respond_stream(
-        State(ThreadState(sender)): State<ThreadState>,
+        State(ThreadState(sender, _)): State<ThreadState>,
         Json(request): Json<CompletionRequest>,
     ) -> Sse<impl Stream<Item = Result<Event>>> {
         let info = request_info(sender.clone(), Duration::from_secs(1)).await;
@@ -236,7 +236,7 @@ mod private {
     };
 
     async fn respond_one(depot: &mut Depot, request: CompletionRequest, res: &mut Response) {
-        let ThreadState(sender) = depot.obtain::<ThreadState>().unwrap();
+        let ThreadState(sender, _) = depot.obtain::<ThreadState>().unwrap();
         let info = request_info(sender.clone(), Duration::from_secs(1)).await;
         let model_name = info.reload.model_path.to_string_lossy().into_owned();
 
@@ -282,7 +282,7 @@ mod private {
     }
 
     async fn respond_stream(depot: &mut Depot, request: CompletionRequest, res: &mut Response) {
-        let ThreadState(sender) = depot.obtain::<ThreadState>().unwrap();
+        let ThreadState(sender, _) = depot.obtain::<ThreadState>().unwrap();
         let info = request_info(sender.clone(), Duration::from_secs(1)).await;
         let model_name = info.reload.model_path.to_string_lossy().into_owned();
 

--- a/src/api/oai/embedding.rs
+++ b/src/api/oai/embedding.rs
@@ -56,7 +56,7 @@ mod private {
 
     /// `/api/oai/embeddings`, `/api/oai/v1/embeddings`.
     pub async fn embeddings(
-        State(ThreadState(sender)): State<ThreadState>,
+        State(ThreadState(sender, _)): State<ThreadState>,
         Json(request): Json<EmbeddingRequest>,
     ) -> Json<EmbeddingResponse> {
         let info = request_info(sender.clone(), Duration::from_secs(1)).await;
@@ -114,7 +114,7 @@ mod private {
         req: JsonBody<EmbeddingRequest>,
     ) -> Json<EmbeddingResponse> {
         let request = req.to_owned(); // req.parse_json::<EmbeddingRequest>().await.unwrap();
-        let ThreadState(sender) = depot.obtain::<ThreadState>().unwrap();
+        let ThreadState(sender, _) = depot.obtain::<ThreadState>().unwrap();
         let info = request_info(sender.clone(), Duration::from_secs(1)).await;
         let model_name = info.reload.model_path.to_string_lossy().into_owned();
 

--- a/src/api/oai/info.rs
+++ b/src/api/oai/info.rs
@@ -24,7 +24,7 @@ mod private {
     use crate::{api::request_info, ThreadState};
 
     /// `/api/oai/models`, `/api/oai/v1/models`.
-    pub async fn models(State(ThreadState(sender)): State<ThreadState>) -> Json<ModelResponse> {
+    pub async fn models(State(ThreadState(sender, _)): State<ThreadState>) -> Json<ModelResponse> {
         let info = request_info(sender, Duration::from_secs(1)).await;
         let model_name = info
             .reload
@@ -52,7 +52,7 @@ mod private {
     /// Model name and id of the current choice.
     #[endpoint]
     pub async fn models(depot: &mut Depot) -> Json<ModelResponse> {
-        let ThreadState(sender) = depot.obtain::<ThreadState>().unwrap();
+        let ThreadState(sender, _) = depot.obtain::<ThreadState>().unwrap();
         let info = request_info(sender.to_owned(), Duration::from_secs(1)).await;
         let model_name = info
             .reload

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,8 @@ impl From<Config> for ReloadRequest {
         let Config {
             model:
                 Model {
-                    path: model_path,
+                    model_name,
+                    model_path,
                     quant,
                     quant_type,
                     turbo,
@@ -43,6 +44,7 @@ impl From<Config> for ReloadRequest {
             ..
         } = value;
         Self {
+            model_name,
             model_path,
             lora,
             quant,
@@ -65,7 +67,10 @@ impl From<Config> for ReloadRequest {
 #[serde(default)]
 pub struct Model {
     /// Path to the model.
-    pub path: PathBuf,
+    pub model_name: PathBuf,
+    /// Path to the model storage folder
+    #[derivative(Default(value = "String::from(\"assets/models\").into()"))]
+    pub model_path: PathBuf,
     /// Specify layers that needs to be quantized.
     pub quant: usize,
     /// Quantization type (Int8 or NF4).


### PR DESCRIPTION
In Config.toml, use model_path and model_name instead the path. The lora.path same to model_name.
BTW: model_name( and lora.path) can be an absolute file path or a file name in the model_path. 
API change, /api/models/list, will search all files in the model_path.
