### PR TITLE
Enabled default value for temperature and top_p

### DIFF
--- a/src/sampler/nucleus.rs
+++ b/src/sampler/nucleus.rs
@@ -11,10 +11,10 @@ use super::Sampler;
 #[derivative(Default)]
 pub struct NucleusParams {
     #[derivative(Default(value = "0.5"))]
-    #[serde(default = "top_p")]
+    #[serde(default = "default_top_p")]
     pub top_p: f32,
     #[derivative(Default(value = "1.0"))]
-    #[serde(default = "temperature")]
+    #[serde(default = "default_temperature")]
     pub temperature: f32,
     #[derivative(Default(value = "0.3"))]
     #[serde(default = "default_presence_penalty")]
@@ -27,11 +27,11 @@ pub struct NucleusParams {
     pub penalty_decay: f32,
 }
 
-fn top_p() -> f32 {
+fn default_top_p() -> f32 {
     NucleusParams::default().top_p
 }
 
-fn temperature() -> f32 {
+fn default_temperature() -> f32 {
     NucleusParams::default().temperature
 }
 

--- a/src/sampler/nucleus.rs
+++ b/src/sampler/nucleus.rs
@@ -11,8 +11,10 @@ use super::Sampler;
 #[derivative(Default)]
 pub struct NucleusParams {
     #[derivative(Default(value = "0.5"))]
+    #[serde(default = "top_p")]
     pub top_p: f32,
     #[derivative(Default(value = "1.0"))]
+    #[serde(default = "temperature")]
     pub temperature: f32,
     #[derivative(Default(value = "0.3"))]
     #[serde(default = "default_presence_penalty")]
@@ -23,6 +25,14 @@ pub struct NucleusParams {
     #[derivative(Default(value = "0.99654026"))]
     #[serde(default = "default_penalty_decay")]
     pub penalty_decay: f32,
+}
+
+fn top_p() -> f32 {
+    NucleusParams::default().top_p
+}
+
+fn temperature() -> f32 {
+    NucleusParams::default().temperature
 }
 
 fn default_presence_penalty() -> f32 {


### PR DESCRIPTION
Hi,

The current version requires the temperature and top_p to be included in the api request, otherwise the api request will fail. 
This PR just enabled the default value of temperature and top_p which actually have been set (to 0.5 and 1.0) but not configured/enabled.