### PR TITLE
Sampling refactor

### DIFF
--- a/crates/ai00-core/src/sampler/mirostat.rs
+++ b/crates/ai00-core/src/sampler/mirostat.rs
@@ -47,7 +47,7 @@ impl Sampler for MirostatSampler {
         let sorted = probs
             .iter()
             .enumerate()
-            .sorted_unstable_by(|(_, x), (_, y)| x.total_cmp(y).reverse())
+            .sorted_unstable_by(|(_, x), (_, y)| y.total_cmp(x))
             .scan((0, 0.0, 0.0), |(_, cum, _), (id, x)| {
                 // if *cum > params.top_p {
                 //     None

--- a/crates/ai00-core/src/sampler/nucleus.rs
+++ b/crates/ai00-core/src/sampler/nucleus.rs
@@ -72,7 +72,7 @@ impl Sampler for NucleusSampler {
         let sorted = probs
             .iter()
             .enumerate()
-            .sorted_unstable_by(|(_, x), (_, y)| x.total_cmp(y).reverse())
+            .sorted_unstable_by(|(_, x), (_, y)| y.total_cmp(x))
             .take(params.top_k)
             .scan((0, 0.0, 0.0), |(_, cum, _), (id, x)| {
                 if *cum > params.top_p {

--- a/crates/ai00-core/src/sampler/typical.rs
+++ b/crates/ai00-core/src/sampler/typical.rs
@@ -69,8 +69,7 @@ impl Sampler for TypicalSampler {
     fn sample(&mut self, probs: &[f32]) -> u16 {
         let TypicalSampler { params, state } = self;
 
-        let entropy: f32 = probs.iter().map(|x| -x * x.ln()).sum();
-
+        let entropy = -probs.iter().map(|x| x * x.ln()).sum::<f32>();
         let sorted = probs
             .iter()
             .map(|&x| (x, (x - entropy).abs()))

--- a/crates/ai00-core/src/sampler/typical.rs
+++ b/crates/ai00-core/src/sampler/typical.rs
@@ -74,7 +74,7 @@ impl Sampler for TypicalSampler {
             .iter()
             .map(|&x| (x, (x - entropy).abs()))
             .enumerate()
-            .sorted_unstable_by(|(_, (_, x)), (_, (_, y))| y.total_cmp(x))
+            .sorted_unstable_by(|(_, (_, x)), (_, (_, y))| x.total_cmp(y))
             .map(|(id, (x, _))| (id, x))
             .take(params.top_k)
             .scan((0, 0.0, 0.0), |(_, cum, _), (id, x)| {

--- a/crates/ai00-core/src/sampler/typical.rs
+++ b/crates/ai00-core/src/sampler/typical.rs
@@ -75,14 +75,15 @@ impl Sampler for TypicalSampler {
             .iter()
             .map(|&x| (x, (x - entropy).abs()))
             .enumerate()
-            .sorted_unstable_by(|(_, (_, x)), (_, (_, y))| x.total_cmp(y).reverse())
+            .sorted_unstable_by(|(_, (_, x)), (_, (_, y))| y.total_cmp(x))
+            .map(|(id, (x, _))| (id, x))
             .take(params.top_k)
             .scan((0, 0.0, 0.0), |(_, cum, _), (id, x)| {
                 if *cum > params.tau {
                     None
                 } else {
-                    *cum += x.1;
-                    Some((id, *cum, x.0))
+                    *cum += x;
+                    Some((id, *cum, x))
                 }
             })
             .map(|(id, _, x)| (id, x.powf(1.0 / params.temperature)))

--- a/crates/ai00-server/src/api/oai/chat.rs
+++ b/crates/ai00-server/src/api/oai/chat.rs
@@ -60,6 +60,8 @@ pub struct ChatRequest {
     #[serde(default)]
     #[serde(alias = "logit_bias")]
     bias: HashMap<u16, f32>,
+    #[serde(default)]
+    bnf_schema: Option<String>,
     #[serde(flatten)]
     sampler: NucleusParams,
     #[serde(default)]
@@ -76,8 +78,9 @@ impl Default for ChatRequest {
             stop: Array::Item("\n\n".into()),
             stream: false,
             bias: HashMap::new(),
+            bnf_schema: Default::default(),
             sampler: Default::default(),
-            sampler_override: None,
+            sampler_override: Default::default(),
         }
     }
 }
@@ -101,6 +104,7 @@ impl From<ChatRequest> for GenerateRequest {
             sampler,
             sampler_override,
             bias,
+            bnf_schema,
             ..
         } = value;
 
@@ -142,6 +146,7 @@ impl From<ChatRequest> for GenerateRequest {
             stop,
             sampler,
             bias,
+            bnf_schema,
             state,
             ..Default::default()
         }

--- a/crates/ai00-server/src/api/oai/completion.rs
+++ b/crates/ai00-server/src/api/oai/completion.rs
@@ -53,7 +53,7 @@ impl Default for CompletionRequest {
             bias: HashMap::new(),
             bnf_schema: Default::default(),
             sampler: Default::default(),
-            sampler_override: None,
+            sampler_override: Default::default(),
         }
     }
 }


### PR DESCRIPTION
- Supports typical sampling (Now APIs use `sampler_override` for advanced sampling)
- Chat mode supports BNF