### PR TITLE
Use radix sort for samplers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -1659,13 +1660,14 @@ dependencies = [
 
 [[package]]
 name = "kbnf"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480e80d8fadff72f7a7267646177ac7ac3e29ada0f0a02241c35182913f406c4"
+checksum = "5c3af046fd2069ae28b943a26d0539f344cb18f522b21cdac2329e4504aab1ca"
 dependencies = [
  "ahash 0.8.11",
  "displaydoc",
  "fixedbitset-stack",
+ "getrandom",
  "jaggedarray",
  "kbnf-regex-automata",
  "kbnf-syntax",
@@ -1692,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "kbnf-syntax"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4c575a961efe76523068d29c9362744f6185e6a8d0de7d4563079fc7e0365b"
+checksum = "d45547018cff6095c33df1543d70076837390d40cabc924c069c39b84210c8bd"
 dependencies = [
  "kbnf-regex-automata",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "serde",
  "tokio",
  "uuid",
+ "voracious_radix_sort",
  "web-rwkv",
 ]
 
@@ -4014,6 +4015,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "voracious_radix_sort"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446e7ffcb6c27a71d05af7e51ef2ee5b71c48424b122a832f2439651e1914899"
 
 [[package]]
 name = "walkdir"

--- a/crates/ai00-core/Cargo.toml
+++ b/crates/ai00-core/Cargo.toml
@@ -17,6 +17,7 @@ cbor4ii = { version = "0.3.2", features = ["serde1"] }
 fastrand = "2"
 half = "2.4"
 kbnf = "0.1.6"
+voracious_radix_sort = "1.2.0"
 qp-trie = "0.8"
 rustc-hash = "1.1.0"
 uuid = { version = "1.8.0", features = ["serde", "v4"] }

--- a/crates/ai00-core/Cargo.toml
+++ b/crates/ai00-core/Cargo.toml
@@ -16,7 +16,7 @@ bytemuck = "1"
 cbor4ii = { version = "0.3.2", features = ["serde1"] }
 fastrand = "2"
 half = "2.4"
-kbnf = "0.1.3"
+kbnf = "0.1.6"
 qp-trie = "0.8"
 rustc-hash = "1.1.0"
 uuid = { version = "1.8.0", features = ["serde", "v4"] }

--- a/crates/ai00-core/src/sampler/mod.rs
+++ b/crates/ai00-core/src/sampler/mod.rs
@@ -2,7 +2,7 @@ pub mod bnf;
 pub mod mirostat;
 pub mod nucleus;
 pub mod typical;
-
+mod utils;
 pub trait Sampler {
     /// Initialize the sampler state.
     fn init(&mut self, model_tokens: &[u16]);

--- a/crates/ai00-core/src/sampler/utils.rs
+++ b/crates/ai00-core/src/sampler/utils.rs
@@ -20,7 +20,7 @@ impl Radixable<f32> for F32WithIndex {
     }
 }
 #[derive(Copy, Clone, Debug)]
-pub struct DoubleF32WithIndex(pub usize, pub f32,pub f32);
+pub struct DoubleF32WithIndex(pub usize, pub f32, pub f32);
 impl PartialOrd for DoubleF32WithIndex {
     fn partial_cmp(&self, other: &DoubleF32WithIndex) -> Option<Ordering> {
         self.2.partial_cmp(&other.2)

--- a/crates/ai00-core/src/sampler/utils.rs
+++ b/crates/ai00-core/src/sampler/utils.rs
@@ -1,0 +1,40 @@
+use std::cmp::Ordering;
+use voracious_radix_sort::Radixable;
+#[derive(Copy, Clone, Debug)]
+pub struct F32WithIndex(pub usize, pub f32);
+impl PartialOrd for F32WithIndex {
+    fn partial_cmp(&self, other: &F32WithIndex) -> Option<Ordering> {
+        self.1.partial_cmp(&other.1)
+    }
+}
+impl PartialEq for F32WithIndex {
+    fn eq(&self, other: &Self) -> bool {
+        self.1 == other.1
+    }
+}
+impl Radixable<f32> for F32WithIndex {
+    type Key = f32;
+    #[inline]
+    fn key(&self) -> Self::Key {
+        self.1
+    }
+}
+#[derive(Copy, Clone, Debug)]
+pub struct DoubleF32WithIndex(pub usize, pub f32,pub f32);
+impl PartialOrd for DoubleF32WithIndex {
+    fn partial_cmp(&self, other: &DoubleF32WithIndex) -> Option<Ordering> {
+        self.2.partial_cmp(&other.2)
+    }
+}
+impl PartialEq for DoubleF32WithIndex {
+    fn eq(&self, other: &Self) -> bool {
+        self.2 == other.2
+    }
+}
+impl Radixable<f32> for DoubleF32WithIndex {
+    type Key = f32;
+    #[inline]
+    fn key(&self) -> Self::Key {
+        self.2
+    }
+}


### PR DESCRIPTION
- Use radix sort for samplers
- Bump `kbnf` version to `v0.1.6`